### PR TITLE
I'm fixing media seeking by handling Range requests. The default Djan…

### DIFF
--- a/backend/anime/media_views.py
+++ b/backend/anime/media_views.py
@@ -1,0 +1,77 @@
+import os
+import re
+import mimetypes
+from wsgiref.util import FileWrapper
+
+from django.http import StreamingHttpResponse, Http404
+from django.views import View
+from django.conf import settings
+
+range_re = re.compile(r'bytes\s*=\s*(\d+)\s*-\s*(\d*)', re.I)
+
+class RangeFileWrapper(object):
+    def __init__(self, filelike, blksize=8192, offset=0, length=None):
+        self.filelike = filelike
+        self.filelike.seek(offset, os.SEEK_SET)
+        self.remaining = length
+        self.blksize = blksize
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.remaining is None:
+            # If remaining is None, we're reading the entire file.
+            data = self.filelike.read(self.blksize)
+            if data:
+                return data
+            raise StopIteration()
+        else:
+            if self.remaining <= 0:
+                raise StopIteration()
+            data = self.filelike.read(min(self.remaining, self.blksize))
+            if not data:
+                raise StopIteration()
+            self.remaining -= len(data)
+            return data
+
+    next = __next__
+
+
+def range_file_response(request, file_path, content_type):
+    range_header = request.META.get('HTTP_RANGE', '').strip()
+    range_match = range_re.match(range_header)
+    size = os.path.getsize(file_path)
+
+    if range_match:
+        first_byte, last_byte = range_match.groups()
+        first_byte = int(first_byte) if first_byte else 0
+        last_byte = int(last_byte) if last_byte else size - 1
+        if last_byte >= size:
+            last_byte = size - 1
+        length = last_byte - first_byte + 1
+        resp = StreamingHttpResponse(RangeFileWrapper(open(file_path, 'rb'), offset=first_byte, length=length), status=206, content_type=content_type)
+        resp['Content-Length'] = str(length)
+        resp['Content-Range'] = 'bytes %s-%s/%s' % (first_byte, last_byte, size)
+    else:
+        resp = StreamingHttpResponse(FileWrapper(open(file_path, 'rb')), content_type=content_type)
+        resp['Content-Length'] = str(size)
+
+    resp['Accept-Ranges'] = 'bytes'
+    return resp
+
+class ServeMediaView(View):
+    def get(self, request, path):
+        # Construct the full path to the media file
+        full_path = os.path.join(settings.MEDIA_ROOT, path)
+
+        # Check if the file exists and is a file
+        if not os.path.exists(full_path) or not os.path.isfile(full_path):
+            raise Http404("File not found")
+
+        # Guess the content type
+        content_type, encoding = mimetypes.guess_type(full_path)
+        content_type = content_type or 'application/octet-stream'
+
+        # Create a streaming response that supports range requests
+        return range_file_response(request, full_path, content_type)

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -1,7 +1,6 @@
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
 from django.conf import settings
-from django.conf.urls.static import static
 from rest_framework.routers import DefaultRouter
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from drf_yasg.views import get_schema_view
@@ -12,6 +11,7 @@ from rest_framework import permissions
 from novel.views import VolumeViewSet, ChapterViewSet
 from wiki.views import CharacterViewSet
 from anime.views import AnimeSeasonViewSet, EpisodeViewSet
+from anime.media_views import ServeMediaView
 
 # Настройка Swagger
 schema_view = get_schema_view(
@@ -40,8 +40,5 @@ urlpatterns = [
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+    re_path(r'^media/(?P<path>.*)$', ServeMediaView.as_view(), name='serve_media'),
 ]
-
-# Для отображения медиа файлов в режиме разработки
-if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
…go development server doesn't support the HTTP Range requests that are necessary for audio and video seeking. I will introduce a custom view to handle these requests, which will allow you to seek through your audio and video content.